### PR TITLE
feat(celery): enable SSL thread pool and conditional TLS config

### DIFF
--- a/entrypoint-celery.sh
+++ b/entrypoint-celery.sh
@@ -3,4 +3,4 @@
 
 
 QUEUE=${1:-playlog_q}
-celery -A koala worker -Q $QUEUE --concurrency=1 --loglevel=info -n ${QUEUE}_worker@%h
+celery -A koala worker -Q $QUEUE --concurrency=1 --loglevel=info --pool threads -n ${QUEUE}_worker@%h

--- a/koala/celery.py
+++ b/koala/celery.py
@@ -1,4 +1,5 @@
 import os
+import ssl
 
 from celery import Celery
 
@@ -7,6 +8,13 @@ from koala import settings
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'koala.settings')
 
 app = Celery('koala')
+
+if settings.ENV != 'local':
+    app.conf.broker_use_ssl = {
+        'ssl_cert_reqs': ssl.CERT_REQUIRED,
+        'ssl_ca_certs': settings.RABBITMQ_CA_CERT_PATH,
+    }
+
 
 app.conf.broker_url = settings.CELERY_BROKER_URL
 app.conf.result_backend = settings.CELERY_RESULT_BACKEND

--- a/koala/settings.py
+++ b/koala/settings.py
@@ -204,9 +204,16 @@ RABBITMQ_PORT = os.environ.get('RABBITMQ_PORT', '5672')
 RABBITMQ_USER = os.environ.get('RABBITMQ_DEFAULT_USER', 'koala')
 RABBITMQ_PASSWORD = os.environ.get('RABBITMQ_DEFAULT_PASS', 'p@ss1234')
 
+if ENV == 'local':
+    # port should be 5672
+    MQ_PROTOCOL = 'amqp'
+else:
+    # port should be 5671
+    MQ_PROTOCOL = 'amqps'
+    RABBITMQ_CA_CERT_PATH = os.environ.get('RABBITMQ_CA_CERT_PATH')
 
-CELERY_BROKER_URL = (
-    f'amqp://{RABBITMQ_USER}:{RABBITMQ_PASSWORD}@{RABBITMQ_HOST}:{RABBITMQ_PORT}//'
-)
+CELERY_BROKER_URL = f'{MQ_PROTOCOL}://{RABBITMQ_USER}:{RABBITMQ_PASSWORD}@{RABBITMQ_HOST}:{RABBITMQ_PORT}//'
+
+
 CELERY_RESULT_BACKEND = f'redis://{REDIS_HOST}:{REDIS_PORT}/0'
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'


### PR DESCRIPTION
CU-86eu561e8

- add --pool threads to entrypoint to prevent SSL hang issues under fork
- import ssl and add broker_use_ssl configuration in celery.py for non-local env
- use MQ_PROTOCOL to switch between amqp/amqps and ensure proper port usage