### PR TITLE
feat: add blacklist functionality to support logout

### DIFF
--- a/account/caches.py
+++ b/account/caches.py
@@ -12,6 +12,35 @@ from utils.constants import RowAccessLevel
 logger = logging.getLogger(__name__)
 
 
+class TokenBlacklistCache:
+    CACHE_TIMEOUT = 60 * 60 * 24
+    CACHE_KEY_PATTERN = 'token_blacklist:{token_jti}'
+
+    @classmethod
+    def _compose_cache_key(cls, token_jti: str) -> str:
+        return cls.CACHE_KEY_PATTERN.format(token_jti=token_jti)
+
+    @classmethod
+    def add_token_to_blacklist(cls, token_jti: str) -> None:
+        """將token JTI加入黑名單"""
+        cache_key = cls._compose_cache_key(token_jti)
+        cache.set(cache_key, True, cls.CACHE_TIMEOUT)
+        logger.info(f"Added token {token_jti} to blacklist")
+
+    @classmethod
+    def is_token_blacklisted(cls, token_jti: str) -> bool:
+        """檢查token是否在黑名單中"""
+        cache_key = cls._compose_cache_key(token_jti)
+        return cache.get(cache_key, False)
+
+    @classmethod
+    def remove_token_from_blacklist(cls, token_jti: str) -> None:
+        """從黑名單中移除token"""
+        cache_key = cls._compose_cache_key(token_jti)
+        cache.delete(cache_key)
+        logger.info(f"Removed token {token_jti} from blacklist")
+
+
 class PermissionCache:
     CACHE_TIMEOUT = 60 * 60 * 24  # 1 day
     CACHE_KEY_PATTERN = 'perms:{profile_type}:{profile_id}:{model_name}'

--- a/account/views/auth.py
+++ b/account/views/auth.py
@@ -86,8 +86,14 @@ def refresh_token_view(request):
 @api_view(['POST'])
 def logout_view(request):
     try:
-        # 在實際應用中，你可能需要將 refresh_token 加入黑名單
-        # 這裡只是簡單的登出回應
+        auth_header = request.META.get('HTTP_AUTHORIZATION', '')
+        if auth_header.startswith('Bearer '):
+            access_token = auth_header.split(' ')[1]
+            JWTService.blacklist_access_token(access_token)
+
+        refresh_token = request.data.get('refresh_token')
+        if refresh_token:
+            JWTService.blacklist_refresh_token(refresh_token)
 
         return APISuccessResponse(msg=ResponseMessage.SUCCESS)
 


### PR DESCRIPTION
CU-86euy1hh5


🎯 實現目標

  將logout功能從單純回傳成功改為真正撤銷token，使用快取黑名單機制防止已登出的token繼續使用。

  🔧 技術實現

  1. TokenBlacklistCache 類別 (account/caches.py)

  - 使用Django快取系統存儲被撤銷的token JTI
  - 24小時過期時間，與token生命週期一致
  - 提供統一的cache key管理方法

  2. JWT服務擴展 (account/jwt.py)

  - validate_token(): 檢查access token JTI是否在黑名單
  - refresh_access_token(): 檢查refresh token JTI是否在黑名單
  - blacklist_access_token(): 將access token加入黑名單
  - blacklist_refresh_token(): 將refresh token加入黑名單

  3. Logout Endpoint更新 (account/views/auth.py)

  - 從Authorization header取得access token並加入黑名單
  - 從request body取得refresh token並加入黑名單
  - 雙重保護：兩種token都被撤銷

  🛡️ 安全特性

  - 完全登出: access token和refresh token都被撤銷
  - 即時生效: 黑名單檢查在每次token驗證時進行
  - 防止重放: 已撤銷的refresh token無法獲取新的access token
  - 自動清理: 快取過期時間與token生命週期一致