### PR TITLE
feat: add pagination for route api

### DIFF
--- a/statistic/pagination.py
+++ b/statistic/pagination.py
@@ -1,0 +1,142 @@
+from collections import defaultdict
+from typing import List, OrderedDict
+
+from django.core.paginator import InvalidPage, Paginator
+from rest_framework.exceptions import NotFound
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class MemberRouteListPagination(PageNumberPagination):
+    """
+    專門用於member聚合數據的分頁器
+    先對member進行分頁，再聚合每個member的相關數據
+    """
+
+    page_size = 10
+    page_size_query_param = 'limit'
+    page_query_param = 'offset'
+    max_page_size = 100
+
+    def get_page_number(self, request, paginator):
+        """
+        從offset參數計算頁碼
+        offset=0 -> page=1, offset=10 -> page=2 (當page_size=10時)
+        """
+        offset = request.query_params.get(self.page_query_param, 0)
+        try:
+            offset = int(offset)
+        except (TypeError, ValueError):
+            offset = 0
+
+        page_number = (offset // self.get_page_size(request)) + 1
+        return page_number
+
+    def paginate_queryset(self, queryset, request, view=None):
+        """
+        對queryset進行member聚合分頁
+        """
+        # 獲取分頁大小
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return None
+
+        # 先獲取所有有數據的member_ids（去重並排序）
+        member_ids = (
+            queryset.values_list('ride_session__bike_rental__member_id', flat=True)
+            .distinct()
+            .order_by('ride_session__bike_rental__member_id')
+        )
+
+        # 對member_ids分頁
+        paginator = Paginator(list(member_ids), page_size)
+        page_number = self.get_page_number(request, paginator)
+
+        try:
+            self.page = paginator.page(page_number)
+        except InvalidPage as exc:
+            msg = self.invalid_page_message.format(
+                page_number=page_number, message=str(exc)
+            )
+            raise NotFound(msg)
+
+        # 獲取當前頁的member_ids
+        paginated_member_ids = self.page.object_list
+
+        # 根據分頁後的member_ids查詢對應的數據
+        filtered_queryset = queryset.filter(
+            ride_session__bike_rental__member_id__in=paginated_member_ids
+        )
+
+        # 按member聚合數據
+        member_routes = defaultdict(list)
+        for route_match in filtered_queryset:
+            member = route_match.ride_session.bike_rental.member
+            member_routes[member.id].append(route_match)
+
+        # 構建結果，保持member_id的順序
+        result_data = []
+        for member_id in paginated_member_ids:
+            if member_id in member_routes:
+                routes = member_routes[member_id]
+                member = routes[0].ride_session.bike_rental.member
+                result_data.append({'member': member, 'routes': routes})
+
+        # 如果沒有數據，返回None讓DRF處理
+        if len(result_data) == 0:
+            return None
+
+        return result_data
+
+    def get_paginated_response(self, data):
+        """
+        返回標準的DRF分頁響應格式
+        """
+        return Response(
+            OrderedDict(
+                [
+                    ('count', self.page.paginator.count),
+                    ('next', self.get_next_link()),
+                    ('previous', self.get_previous_link()),
+                    ('results', data),
+                ]
+            )
+        )
+
+    def get_next_link(self):
+        """
+        生成下一頁的連結（使用offset參數）
+        """
+        if not self.page.has_next():
+            return None
+
+        page_number = self.page.next_page_number()
+        offset = (page_number - 1) * self.get_page_size(self.request)
+        return self.replace_query_param(
+            self.request.build_absolute_uri(), self.page_query_param, offset
+        )
+
+    def get_previous_link(self):
+        """
+        生成上一頁的連結（使用offset參數）
+        """
+        if not self.page.has_previous():
+            return None
+
+        page_number = self.page.previous_page_number()
+        offset = (page_number - 1) * self.get_page_size(self.request)
+        return self.replace_query_param(
+            self.request.build_absolute_uri(), self.page_query_param, offset
+        )
+
+    def replace_query_param(self, url, key, val):
+        """
+        替換URL中的查詢參數
+        """
+        from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+        parsed = urlparse(url)
+        query_dict = parse_qs(parsed.query, keep_blank_values=True)
+        query_dict[key] = [str(val)]
+        new_query = urlencode(query_dict, doseq=True)
+        return urlunparse(parsed._replace(query=new_query))


### PR DESCRIPTION
CU-86euy1rw5



🎯 目標達成

  為/api/statistic/routes/端點實現了基於member聚合的分頁功能，解決了大量路線數據時的性能問題。

  🔧 核心實現

  1. 專用分頁器 (statistic/pagination.py)

  新增MemberRouteListPagination類：
  - 繼承DRF的PageNumberPagination
  - 實現member聚合的分頁邏輯
  - 支持limit/offset參數
  - 返回標準DRF分頁響應格式

  2. 分頁邏輯流程

  1. 查詢所有有路線的member_ids（去重並排序）
  2. 對member_ids進行分頁
  3. 根據分頁後的member_ids查詢對應routes
  4. 按member聚合routes數據
  5. 保持member順序一致性

  3. ViewSet更新 (statistic/views.py)

  - 添加pagination_class = MemberRouteListPagination
  - 更新list方法使用分頁器
  - 保留原始聚合邏輯作為fallback

  📋 API使用方式

  # 基本分頁
  GET /api/statistic/routes/?limit=10&offset=0

  # 第二頁
  GET /api/statistic/routes/?limit=10&offset=10

  # 配合過濾器
  GET /api/statistic/routes/?limit=5&offset=0&end_time__date=2025-09-22

  📄 響應格式

  {
    "count": 100,           // 總member數量
    "next": "next_page_url",// 下一頁URL  
    "previous": "prev_url", // 上一頁URL
    "results": [            // 當前頁member及其routes
      {
        "member": {
          "id": 113,
          "full_name": "測試會員",
          "phone": "+886912345001"
        },
        "routes": [/* 該member的所有routes */]
      }
    ]
  }

  ✅ 優勢特性

  - 性能優化：按member分頁避免單次載入過多路線數據
  - 業務邏輯：符合以member為主體查看路線的使用場景
  - 標準化：使用DRF標準分頁格式，前端易於處理
  - 向後相容：保留原始聚合邏輯作為fallback
  - 靈活性：支持自定義分頁大小和offset