### PR TITLE
feat: add pagination for telemetry device api

### DIFF
--- a/bike/signals.py
+++ b/bike/signals.py
@@ -1,8 +1,9 @@
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.utils import timezone
 
 from bike.models import BikeInfo, BikeRealtimeStatus
+from telemetry.models import TelemetryDevice
 
 
 @receiver(post_save, sender=BikeInfo)
@@ -20,3 +21,38 @@ def create_bike_realtime_status(sender, instance, created, **kwargs):
             status=BikeRealtimeStatus.StatusOptions.IDLE,
             last_seen=timezone.now(),
         )
+
+
+@receiver(post_save, sender=BikeInfo)
+def handle_telemetry_device_status(sender, instance, created, **kwargs):
+    """
+    當 BikeInfo 建立或更新時，自動處理 TelemetryDevice 狀態
+    """
+    # 如果腳踏車有分配遙測設備，將設備狀態設為 DEPLOYED
+    if instance.telemetry_device:
+        telemetry_device = instance.telemetry_device
+        if telemetry_device.status != TelemetryDevice.StatusOptions.DEPLOYED:
+            telemetry_device.status = TelemetryDevice.StatusOptions.DEPLOYED
+            telemetry_device.save()
+
+
+@receiver(pre_save, sender=BikeInfo)
+def handle_telemetry_device_release(sender, instance, **kwargs):
+    """
+    當 BikeInfo 更新前，處理舊的 TelemetryDevice 釋放
+    """
+    if instance.pk:  # 只處理更新，不處理新建
+        try:
+            old_bike = BikeInfo.objects.get(pk=instance.pk)
+
+            # 如果舊的遙測設備與新的不同，釋放舊設備
+            if (
+                old_bike.telemetry_device
+                and old_bike.telemetry_device != instance.telemetry_device
+            ):
+                old_device = old_bike.telemetry_device
+                old_device.status = TelemetryDevice.StatusOptions.AVAILABLE
+                old_device.save()
+
+        except BikeInfo.DoesNotExist:
+            pass

--- a/simulator/data_factory.py
+++ b/simulator/data_factory.py
@@ -149,7 +149,7 @@ class SimulationDataFactory:
                 defaults={
                     'name': device_name,
                     'model': 'SIMULATOR-TELEMETRY-2024',
-                    'status': 'active',
+                    'status': TelemetryDevice.StatusOptions.AVAILABLE,
                 },
             )
             devices.append(device)

--- a/telemetry/views.py
+++ b/telemetry/views.py
@@ -2,6 +2,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, serializers, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.filters import SearchFilter
+from rest_framework.pagination import LimitOffsetPagination
 
 from account.simple_permissions import IsAdmin, IsStaff
 from telemetry.filters import TelemetryDeviceFilter
@@ -29,6 +30,7 @@ class TelemetryDeviceViewSet(
     permission_classes = [IsStaff | IsAdmin]
     filter_backends = [DjangoFilterBackend]
     filterset_class = TelemetryDeviceFilter
+    pagination_class = LimitOffsetPagination
 
     def get_serializer_class(self):
         match self.action:


### PR DESCRIPTION
CU-86euy3383



🎯 問題修復

  修復了simulator中TelemetryDevice狀態管理的問題，並為TelemetryDevice API添加了分頁功能。

  🔧 主要修改

  1. 修復TelemetryDevice狀態問題 (simulator/data_factory.py)

  - 修復前: 使用無效狀態 'active'
  - 修復後: 使用正確狀態 TelemetryDevice.StatusOptions.AVAILABLE
  - 影響: 確保simulator創建的設備狀態符合系統規範

  2. 添加自動狀態管理Signal (bike/signals.py)

  新增兩個signal handler來自動管理TelemetryDevice狀態：

  handle_telemetry_device_status - post_save
  - 當BikeInfo創建/更新時自動執行
  - 如果腳踏車分配了遙測設備，自動將設備狀態設為 DEPLOYED

  handle_telemetry_device_release - pre_save
  - 當BikeInfo更新前自動執行
  - 如果更換遙測設備，自動將舊設備狀態改回 AVAILABLE

  3. TelemetryDevice API分頁功能 (telemetry/views.py)

  - 添加 pagination_class = LimitOffsetPagination
  - 支持 limit 和 offset 參數
  - 與其他API保持一致的分頁行為

  🔄 完整的狀態管理流程

  設備狀態轉換:

  1. 創建 → AVAILABLE (可分配)
  2. 分配給腳踏車 → DEPLOYED (已部署)
  3. 腳踏車刪除/設備更換 → AVAILABLE (重新可分配)
  4. 維護時 → MAINTENANCE (維護中)

  自動化處理:

  - ✅ Simulator流程: 創建設備 → 創建腳踏車 → Signal自動設為DEPLOYED
  - ✅ API流程: 使用BikeManagementService的方法處理狀態
  - ✅ 更新流程: Signal自動處理設備的釋放與重新分配

  📋 API使用範例

  # 基本列表 (返回所有設備)
  GET /api/telemetry/devices/

  # 分頁列表
  GET /api/telemetry/devices/?limit=10&offset=0

  # 結合過濾與分頁
  GET /api/telemetry/devices/?status=deployed&limit=5&offset=0


  ✅ 優勢特性

  - 狀態一致性: 無論通過simulator還是API操作，設備狀態都正確管理
  - 自動化處理: Signal自動處理狀態轉換，減少手動操作錯誤
  - 向後相容: 不影響現有API行為，只是增加了分頁功能
  - 標準化: 使用與其他API一致的分頁機制